### PR TITLE
Default indexes for ledger_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.1.5.pre
+
+- Add default `ledger_entries` read-performance indexes to new-install generator migration.
+- Add `rails generate ledger_accountable --add-indexes` upgrade path for existing installations.
+- Add additive index migration template with idempotent guards (`index_exists?`) and adapter-aware behavior:
+  - PostgreSQL: `algorithm: :concurrently` with `disable_ddl_transaction!`
+  - Other adapters: standard `add_index`
+- Document existing-install upgrade flow and default index set in README.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To create the requisite migrations and models, run:
 $ rails generate ledger_accountable
 ```
 
+For existing installations that already have `ledger_entries`, generate only the additive index migration:
+
+```bash
+$ rails generate ledger_accountable --add-indexes
+```
+
 ## Usage
 
 ### `LedgerAccountable::LedgerOwner`
@@ -113,5 +119,22 @@ Ledger entries are automatically created in the following scenarios:
 - **`:modification`** - When an item's amount changes
 
 When a LedgerItem changes owners, both a `deletion` entry for the old owner and an `addition` entry for the new owner are created in the same transaction
+
+## Upgrading Existing Installations
+
+Existing apps should run:
+
+```bash
+$ rails generate ledger_accountable --add-indexes
+```
+
+This generates an additive migration that adds the default read-performance indexes for `ledger_entries`:
+
+- `[:owner_type, :owner_id, :transaction_type]`
+- `[:owner_type, :owner_id, :entry_type]`
+- `[:owner_type, :owner_id, :created_at, :id]`
+- `[:ledger_item_type, :ledger_item_id, :created_at, :id]`
+
+For PostgreSQL, indexes are added with `algorithm: :concurrently`. Other adapters use standard `add_index`.
 
 <!-- TODO: documentation for alternate object destruction libraries: callbacks to trigger ledger removal for objects that aren't destroyed -->

--- a/lib/generators/ledger_accountable/ledger_accountable_generator.rb
+++ b/lib/generators/ledger_accountable/ledger_accountable_generator.rb
@@ -5,20 +5,36 @@ class LedgerAccountableGenerator < Rails::Generators::Base
   include Rails::Generators::Migration
 
   source_root File.expand_path('templates', __dir__)
+  class_option :add_indexes, type: :boolean, default: false,
+                            desc: 'Generate only an additive migration to add missing ledger_entries indexes'
 
   def create_model_file
+    return if options[:add_indexes]
+
     template 'ledger_entry.rb', 'app/models/ledger_entry.rb'
   end
 
   def create_migration_file
+    return if options[:add_indexes]
+
     migration_template 'migration.rb', 'db/migrate/create_ledger_entries.rb'
   end
 
+  def create_add_indexes_migration_file
+    return unless options[:add_indexes]
+
+    migration_template 'add_indexes_migration.rb', 'db/migrate/add_indexes_to_ledger_entries.rb'
+  end
+
   def create_initializer_file
+    return if options[:add_indexes]
+
     template 'initializer.rb', 'config/initializers/ledger_accountable.rb'
   end
 
   def copy_localization_file
+    return if options[:add_indexes]
+
     copy_file '../../../locale/en.yml', 'config/locales/ledger.en.yml'
   end
 

--- a/lib/generators/ledger_accountable/templates/add_indexes_migration.rb
+++ b/lib/generators/ledger_accountable/templates/add_indexes_migration.rb
@@ -1,0 +1,41 @@
+class AddIndexesToLedgerEntries < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index_unless_exists :ledger_entries, [:owner_type, :owner_id, :transaction_type],
+                            name: 'index_ledger_entries_on_owner_and_transaction_type'
+    add_index_unless_exists :ledger_entries, [:owner_type, :owner_id, :entry_type],
+                            name: 'index_ledger_entries_on_owner_and_entry_type'
+    add_index_unless_exists :ledger_entries, [:owner_type, :owner_id, :created_at, :id],
+                            name: 'index_ledger_entries_on_owner_and_created_at_and_id'
+    add_index_unless_exists :ledger_entries, [:ledger_item_type, :ledger_item_id, :created_at, :id],
+                            name: 'index_ledger_entries_on_item_and_created_at_and_id'
+  end
+
+  def down
+    remove_index_if_exists :ledger_entries, name: 'index_ledger_entries_on_owner_and_transaction_type'
+    remove_index_if_exists :ledger_entries, name: 'index_ledger_entries_on_owner_and_entry_type'
+    remove_index_if_exists :ledger_entries, name: 'index_ledger_entries_on_owner_and_created_at_and_id'
+    remove_index_if_exists :ledger_entries, name: 'index_ledger_entries_on_item_and_created_at_and_id'
+  end
+
+  private
+
+  def add_index_unless_exists(table_name, columns, name:)
+    return if index_exists?(table_name, columns, name: name)
+
+    options = { name: name }
+    options[:algorithm] = :concurrently if postgresql?
+    add_index(table_name, columns, **options)
+  end
+
+  def remove_index_if_exists(table_name, name:)
+    return unless index_exists?(table_name, name: name)
+
+    remove_index(table_name, name: name)
+  end
+
+  def postgresql?
+    connection.adapter_name.downcase.include?('postgres')
+  end
+end

--- a/lib/generators/ledger_accountable/templates/migration.rb
+++ b/lib/generators/ledger_accountable/templates/migration.rb
@@ -10,5 +10,14 @@ class CreateLedgerEntries < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+
+    add_index :ledger_entries, [:owner_type, :owner_id, :transaction_type],
+              name: 'index_ledger_entries_on_owner_and_transaction_type'
+    add_index :ledger_entries, [:owner_type, :owner_id, :entry_type],
+              name: 'index_ledger_entries_on_owner_and_entry_type'
+    add_index :ledger_entries, [:owner_type, :owner_id, :created_at, :id],
+              name: 'index_ledger_entries_on_owner_and_created_at_and_id'
+    add_index :ledger_entries, [:ledger_item_type, :ledger_item_id, :created_at, :id],
+              name: 'index_ledger_entries_on_item_and_created_at_and_id'
   end
 end

--- a/lib/ledger_accountable/version.rb
+++ b/lib/ledger_accountable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LedgerAccountable
-  VERSION = '0.1.4.pre'
+  VERSION = '0.1.5.pre'
 end

--- a/test/generator_templates_test.rb
+++ b/test/generator_templates_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../lib/generators/ledger_accountable/ledger_accountable_generator'
+
+class GeneratorTemplatesTest < ActiveSupport::TestCase
+  def test_create_table_migration_includes_default_indexes
+    content = File.read(File.expand_path('../lib/generators/ledger_accountable/templates/migration.rb', __dir__))
+
+    assert_includes content, "index_ledger_entries_on_owner_and_transaction_type"
+    assert_includes content, "index_ledger_entries_on_owner_and_entry_type"
+    assert_includes content, "index_ledger_entries_on_owner_and_created_at_and_id"
+    assert_includes content, "index_ledger_entries_on_item_and_created_at_and_id"
+  end
+
+  def test_add_indexes_migration_uses_postgresql_concurrent_path
+    content = File.read(File.expand_path('../lib/generators/ledger_accountable/templates/add_indexes_migration.rb', __dir__))
+
+    assert_includes content, 'disable_ddl_transaction!'
+    assert_includes content, 'options[:algorithm] = :concurrently if postgresql?'
+    assert_includes content, "connection.adapter_name.downcase.include?('postgres')"
+  end
+
+  def test_add_indexes_migration_is_idempotent
+    content = File.read(File.expand_path('../lib/generators/ledger_accountable/templates/add_indexes_migration.rb', __dir__))
+
+    assert_includes content, 'return if index_exists?(table_name, columns, name: name)'
+    assert_includes content, 'return unless index_exists?(table_name, name: name)'
+  end
+
+  def test_generator_exposes_add_indexes_option
+    add_indexes_option = LedgerAccountableGenerator.class_options['add_indexes']
+
+    refute_nil add_indexes_option
+    assert_equal false, add_indexes_option.default
+  end
+end

--- a/test/generator_templates_test.rb
+++ b/test/generator_templates_test.rb
@@ -29,7 +29,7 @@ class GeneratorTemplatesTest < ActiveSupport::TestCase
   end
 
   def test_generator_exposes_add_indexes_option
-    add_indexes_option = LedgerAccountableGenerator.class_options['add_indexes']
+    add_indexes_option = LedgerAccountableGenerator.class_options[:add_indexes]
 
     refute_nil add_indexes_option
     assert_equal false, add_indexes_option.default

--- a/test/ledger_item_test.rb
+++ b/test/ledger_item_test.rb
@@ -211,7 +211,7 @@ class LedgerItemTest < ActiveSupport::TestCase
         payment.update!(order: @order)
       end
 
-      entry_types = LedgerEntry.order(:created_at).pluck(:entry_type)
+      entry_types = payment.ledger_entries.order(:created_at).pluck(:entry_type)
       # 1. :addition - original creation
       # 2. :deletion - remove from original order ledger
       # 3. :addition - add to order2 ledger


### PR DESCRIPTION
- Added default indexes for new installs in the generated `create_ledger_entries` migration template
- Added an existing-install upgrade path via generator flag `--add-indexes`
- Added additive migration template for existing installs
- Updated docs with upgrade instructions
- Added focused tests for generator/template contracts