### PR TITLE
Pin CI runners to Ubuntu 22.04 for Ruby version compatibility

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build + Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6.pre
+
+- Pin GitHub Actions workflows to `ubuntu-22.04` to restore Ruby `3.0.6` compatibility for CI and gem publishing.
+
 ## 0.1.5.pre
 
 - Add default `ledger_entries` read-performance indexes to new-install generator migration.

--- a/lib/ledger_accountable/version.rb
+++ b/lib/ledger_accountable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LedgerAccountable
-  VERSION = '0.1.5.pre'
+  VERSION = '0.1.6.pre'
 end


### PR DESCRIPTION
Pins GitHub Actions jobs from `ubuntu-latest` to `ubuntu-22.04` so `ruby/setup-ruby` can reliably provision Ruby `3.0.6` again. This fixes the Build + Publish failure caused by `ubuntu-latest` moving to 24.04, where that Ruby version is no longer available via hosted toolcache.